### PR TITLE
Change merge policy to "ours"

### DIFF
--- a/rebasebot/bot.py
+++ b/rebasebot/bot.py
@@ -150,7 +150,7 @@ def _do_merge(gitwd, dest):
     logging.info("Performing merge")
     try:
         gitwd.git.merge(
-            f"dest/{dest.branch}", "-Xtheirs", "-m",
+            f"dest/{dest.branch}", "-Xours", "-m",
             f"UPSTREAM: <carry>: Merge branch '{dest.branch}' in {gitwd.active_branch}"
         )
     except git.GitCommandError as ex:


### PR DESCRIPTION
Currently it is set to "theirs", which is not correct because we bring external changes in this case. To keep it right, we should use "ours" policy for merging.